### PR TITLE
refactor: change MCP tool names from spaces to snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ To use this server with an MCP client (like the VSCode extension or Claude Deskt
 
 The server exposes the following tools via the Model Context Protocol:
 
-1.  **`Get Gradle Project Info`**
+1.  **`get_gradle_project_info`**
     -   **Description**: Retrieves specific details about a Gradle project, returning structured JSON. Allows requesting only necessary information categories (`buildStructure`, `tasks`, `environment`, `projectDetails`). If `requestedInfo` is omitted, all categories are fetched.
     -   **Key Inputs**:
         -   `projectPath` (string, required): Absolute path to the Gradle project root.
         -   `requestedInfo` (array of strings, optional): List of categories to retrieve (e.g., `["tasks", "environment"]`).
     -   **Output**: JSON object (`GradleProjectInfoResponse`) containing the requested data fields and potential errors.
 
-2.  **`Execute Gradle Task`**
+2.  **`execute_gradle_task`**
     -   **Description**: Executes general Gradle tasks (like `build`, `clean`). **Not recommended for running tests if detailed results are needed** (use the test tool instead). Returns formatted text output summarizing execution and including captured stdout/stderr.
     -   **Key Inputs**:
         -   `projectPath` (string, required): Absolute path to the Gradle project root.
@@ -108,7 +108,7 @@ The server exposes the following tools via the Model Context Protocol:
         -   `environmentVariables` (object, optional): Environment variables for the build (e.g., `{"CI": "true"}`).
     -   **Output**: Formatted text response with execution summary, final status (`Success`/`Failure`), and combined stdout/stderr.
 
-3.  **`Run Gradle Tests`**
+3.  **`run_gradle_tests`**
     -   **Description**: Executes Gradle test tasks and returns results as a structured JSON hierarchy (Suite > Class > Test). Filters/truncates output lines by default, focusing on failures. Provides options to include output for passed tests and control log limits.
     -   **Key Inputs**:
         -   `projectPath` (string, required): Absolute path to the Gradle project root.

--- a/src/main/kotlin/me/gulya/gradle/mcp/server/tool/ExecuteTaskTool.kt
+++ b/src/main/kotlin/me/gulya/gradle/mcp/server/tool/ExecuteTaskTool.kt
@@ -14,11 +14,11 @@ import me.gulya.gradle.mcp.inputSchema
 
 class ExecuteTaskTool : GradleTool {
     private val log = logger<ExecuteTaskTool>()
-    override val name = "Execute Gradle Task"
+    override val name = "execute_gradle_task"
     override val description = """
         Executes one or more specified Gradle tasks in a project.
         **Use this for general build lifecycle tasks** (like 'clean', 'build', 'assemble', 'publish') or **custom tasks** defined in the build scripts.
-        **DO NOT use this tool to run tests if you need detailed, per-test results and output.** Use the 'Run Gradle Tests' tool for testing instead.
+        **DO NOT use this tool to run tests if you need detailed, per-test results and output.** Use the 'run_gradle_tests' tool for testing instead.
 
         Allows customization:
         - `tasks`: List of task names to execute (e.g., ['clean', 'build']). Order matters.

--- a/src/main/kotlin/me/gulya/gradle/mcp/server/tool/GetProjectInfoTool.kt
+++ b/src/main/kotlin/me/gulya/gradle/mcp/server/tool/GetProjectInfoTool.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 class GetProjectInfoTool : GradleTool {
     private val log = logger<GetProjectInfoTool>()
-    override val name = "Get Gradle Project Info"
+    override val name = "get_gradle_project_info"
     override val description = """
         Retrieves specific details about a Gradle project, returning structured JSON.
         Allows requesting only the necessary information for better efficiency.

--- a/src/main/kotlin/me/gulya/gradle/mcp/server/tool/RunTestsTool.kt
+++ b/src/main/kotlin/me/gulya/gradle/mcp/server/tool/RunTestsTool.kt
@@ -52,7 +52,7 @@ data class MethodFilterSpec(
 class RunTestsTool : GradleTool {
     private val log = logger<RunTestsTool>()
 
-    override val name = "Run Gradle Tests"
+    override val name = "run_gradle_tests"
     override val description = """
         Runs specified Gradle test tasks (default: ':test'), returning hierarchical JSON results. Supports filtering tests (e.g., by class, method). Output for passed tests is excluded by default (set 'includeOutputForPassed: true' only if debugging passed tests). Output lines are limited by default.
         """.trimIndent()


### PR DESCRIPTION
- Change 'Get Gradle Project Info' to 'get_gradle_project_info'
- Change 'Execute Gradle Task' to 'execute_gradle_task'
- Change 'Run Gradle Tests' to 'run_gradle_tests'

This follows MCP best practices and improves compatibility with tools like Claude-Code that may have issues with space-separated tool names.

Fixes issue #2 